### PR TITLE
Tidal - Rename dims names from x and y to xh and yh

### DIFF
--- a/external_tidal_generation/generate_bottom_roughness_polyfit.py
+++ b/external_tidal_generation/generate_bottom_roughness_polyfit.py
@@ -359,7 +359,7 @@ def main():
             {
                 "h2": xr.DataArray(
                     np.nan_to_num(final_hrms**2, nan=0.0),
-                    dims=("y", "x"),
+                    dims=("yh", "xh"),
                     attrs={
                         "long_name": (
                             "Polynomial-fit bottom roughness squared (h^2) per model grid cell "
@@ -370,7 +370,7 @@ def main():
                 ),
                 "lon": xr.DataArray(
                     lon,
-                    dims=("y", "x"),
+                    dims=("yh", "xh"),
                     attrs={
                         "long_name": "Longitude",
                         "units": "degrees_east",
@@ -378,7 +378,7 @@ def main():
                 ),
                 "lat": xr.DataArray(
                     lat,
-                    dims=("y", "x"),
+                    dims=("yh", "xh"),
                     attrs={
                         "long_name": "Latitude",
                         "units": "degrees_north",

--- a/external_tidal_generation/generate_tide_amplitude.py
+++ b/external_tidal_generation/generate_tide_amplitude.py
@@ -275,6 +275,9 @@ def main():
     # Remove boundary variables and update metadata to tideamp
     tideamp = update_tideamp(tideamp)
 
+    # rename dims name to xh and yh
+    tideamp = tideamp.rename({'x': 'xh', 'y': 'yh'})
+
     # Add provenance metadata and MD5 hashes for input files.
     this_file = os.path.normpath(__file__)
     runcmd = (


### PR DESCRIPTION
This PR updates the dimension names in the external tidal forcing files:
- bottom_roughness.nc
- tide_amp.nc

These files used x and y as dim names, where MOM doesn't like them. The dimensions have now been renamed to xh and yh, consistent with MOM6 expectations. This resolves the `categorize_axes` warning and the crash.

The changes have been tested and confirmed to work and the model runs successfully for 10 days without errors.

A non-critical warning is still printed when reading `tide_amp.nc`. Since the file is static, no other issues are found.
```
WARNING from PE     0: read_field_2d:time level specified, but the variable tideamp does not have an unlimited dimension in ./INPUT/tideamp.nc
```