### PR TITLE
Fix mom6 filename format with non-default I/O layout

### DIFF
--- a/payu_config/archive_scripts/standardise_mom6_filenames.sh
+++ b/payu_config/archive_scripts/standardise_mom6_filenames.sh
@@ -43,7 +43,7 @@ fi
 # process each output directory
 for dir in ${out_dirs[@]}; do
     # process each mom6 file
-    for current_file in $dir/access-om3.mom6.*.nc; do
+    for current_file in $dir/access-om3.mom6.*.nc*; do
        if [ -f $current_file ]; then
             new_filename=$(echo $current_file | sed -E 's/_([0-9]{4})/\1/')
                 # rename the file without overwriting existing files


### PR DESCRIPTION
Closes https://github.com/ACCESS-NRI/om3-scripts/issues/63

Update below two scripts,

- [x] standardise_mom6_filenames.sh
- [x] test_mom6_filenames.py