### PR TITLE
Add script for regridding WOMBAT forcing

### DIFF
--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -191,6 +191,7 @@ def main():
     grid_dest = xr.merge((lon_dest, lat_dest))
 
     # Regrid using bilinear interpolation with nearest neighbour extrapolation
+    # NOTE: This will not conserve global quantities
     regridder = xe.Regridder(
         grid_src,
         grid_dest,

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -7,9 +7,9 @@
 #
 # To run:
 #   python regrid_forcing.py --forcing-filename=<path-to-forcing-file>
-#       --hgrid-filename=<path-to-supergrid-file> --output-filename=<path-to-output-file>
+#     --hgrid-filename=<path-to-supergrid-file> --output-filename=<path-to-output-file>
 # these extra arguments are available if required:
-#     --lon-name=<lon-name> --lat-name=<lat-name>
+#     --mask-filename=<path-to-mask-file>--lon-name=<lon-name> --lat-name=<lat-name>
 #
 # For more information, run `python regrid_forcing.py -h`
 #
@@ -79,20 +79,30 @@ def main():
 
     parser.add_argument(
         "--forcing-filename",
+        type=str,
         required=True,
         help="The path to the forcing file to interpolate.",
     )
 
     parser.add_argument(
         "--hgrid-filename",
+        type=str,
         required=True,
         help="The path to the MOM supergrid file to use as a grid for interpolation.",
     )
 
     parser.add_argument(
         "--output-filename",
+        type=str,
         required=True,
         help="The path to the file to be outputted.",
+    )
+
+    parser.add_argument(
+        "--mask-filename",
+        type=str,
+        default=None,
+        help="The path to a land-sea (0-1) mask for the forcing file. Cells that fall on land in the destination grid will take their values from the nearest source grid cell.",
     )
 
     parser.add_argument(
@@ -113,8 +123,12 @@ def main():
     forcing_filename = os.path.abspath(args.forcing_filename)
     hgrid_filename = os.path.abspath(args.hgrid_filename)
     output_filename = os.path.abspath(args.output_filename)
+    mask_filename = args.mask_filename
     lon_name = args.lon_name
     lat_name = args.lat_name
+
+    if mask_filename:
+        mask_filename = os.path.abspath(mask_filename)
 
     this_file = os.path.normpath(__file__)
 
@@ -123,6 +137,8 @@ def main():
         f"python3 {os.path.basename(this_file)} --forcing-filename={forcing_filename} "
         f"--hgrid-filename={hgrid_filename} --output-filename={output_filename}"
     )
+    if mask_filename:
+        runcmd += f" --mask-filename={mask_filename}"
     if lon_name:
         runcmd += f" --lon-name={lon_name}"
     if lat_name:
@@ -132,6 +148,8 @@ def main():
         f"{forcing_filename} (md5 hash: {md5sum(forcing_filename)})",
         f"{hgrid_filename} (md5 hash: {md5sum(hgrid_filename)})",
     ]
+    if mask_filename:
+        file_hashes.append(f"{mask_filename} (md5 hash: {md5sum(mask_filename)})")
     global_attrs = {
         "history": get_provenance_metadata(this_file, runcmd),
         "inputFile": ", ".join(file_hashes),
@@ -140,6 +158,8 @@ def main():
     # Load the input data
     forcing_src = xr.open_dataset(forcing_filename).compute()
     hgrid = xr.open_dataset(hgrid_filename).compute()
+    if mask_filename:
+        forcing_mask = xr.open_dataset(mask_filename).compute()
 
     # Standardise lon/lat coordinate names
     if not lon_name:
@@ -152,29 +172,39 @@ def main():
 
     # Get source and destination grid
     grid_src = forcing_src[["lon", "lat"]]
+    if mask_filename:
+        # Add the mask to the source grid so that land values are extrapolated
+        grid_src = grid_src.assign(forcing_mask)
 
     # Destination grid is tracer cell centres
     lon_dest = hgrid["x"][1:-1:2, 1:-1:2].to_dataset(name="lon")
     lat_dest = hgrid["y"][1:-1:2, 1:-1:2].to_dataset(name="lat")
     grid_dest = xr.merge((lon_dest, lat_dest))
 
-    # Regrid using bilinear interpolation
-    regridder = xe.Regridder(grid_src, grid_dest, method="bilinear", periodic=True)
+    # Regrid using bilinear interpolation with nearest neighbour extrapolation
+    regridder = xe.Regridder(
+        grid_src,
+        grid_dest,
+        method="bilinear",
+        extrap_method="nearest_s2d",
+        periodic=True,
+    )
     forcing_regrid = regridder(forcing_src)
 
     # Add coodinates and metadata required by data_table
     forcing_regrid = forcing_regrid.assign_coords(
         lon=lon_dest["lon"], lat=lat_dest["lat"]
     )
+    forcing_regrid = forcing_regrid.rename({"nyp": "ny", "nxp": "nx"})
     forcing_regrid = forcing_regrid.assign_coords(
         {
-            "nyp": ("nyp", range(forcing_regrid.sizes["nyp"])),
-            "nxp": ("nxp", range(forcing_regrid.sizes["nxp"])),
+            "ny": ("ny", range(forcing_regrid.sizes["ny"])),
+            "nx": ("nx", range(forcing_regrid.sizes["nx"])),
         }
     )
     forcing_regrid["time"].attrs = dict(axis="T", standard_name="time", modulo="y")
-    forcing_regrid["nyp"].attrs = dict(axis="Y")
-    forcing_regrid["nxp"].attrs = dict(axis="X")
+    forcing_regrid["ny"].attrs = dict(axis="Y")
+    forcing_regrid["nx"].attrs = dict(axis="X")
     forcing_regrid["lat"].attrs = dict(
         long_name="Latitude of T-cell center",
         standard_name="latitude",
@@ -188,7 +218,12 @@ def main():
     forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
 
     # Save output
-    forcing_regrid.to_netcdf(output_filename, unlimited_dims="time")
+    comp = dict(zlib=True, complevel=4)
+    encoding = {var: comp for var in forcing_regrid.data_vars}
+    unlimited_dims = "time" if "time" in forcing_regrid.dims else None
+    forcing_regrid.to_netcdf(
+        output_filename, unlimited_dims=unlimited_dims, encoding=encoding
+    )
 
 
 if __name__ == "__main__":

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -102,21 +102,30 @@ def main():
         "--mask-filename",
         type=str,
         default=None,
-        help="The path to a land-sea (0-1) mask for the forcing file. Cells that fall on land in the destination grid will take their values from the nearest source grid cell.",
+        help=(
+            "The path to a land-sea (0-1) mask for the forcing file. Cells that fall on land in "
+            "the destination grid will take their values from the nearest source grid cell."
+        ),
     )
 
     parser.add_argument(
         "--lon-name",
         type=str,
         default=None,
-        help="The name of the longitude variable in the input grid. If not passed, an attempt will be made to guess the name.",
+        help=(
+            "The name of the longitude variable in the input grid. If not passed, an attempt will "
+            "be made to guess the name."
+        ),
     )
 
     parser.add_argument(
         "--lat-name",
         type=str,
         default=None,
-        help="The name of the latitude variable in the input grid. If not passed, an attempt will be made to guess the name.",
+        help=(
+            "The name of the latitude variable in the input grid. If not passed, an attempt will "
+            "be made to guess the name."
+        ),
     )
 
     args = parser.parse_args()

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -172,14 +172,17 @@ def main():
             "nxp": ("nxp", range(forcing_regrid.sizes["nxp"])),
         }
     )
-    forcing_regrid["time"].attrs = dict(axis="T", modulo="y")
+    forcing_regrid["time"].attrs = dict(axis="T", standard_name="time", modulo="y")
     forcing_regrid["nyp"].attrs = dict(axis="Y")
     forcing_regrid["nxp"].attrs = dict(axis="X")
     forcing_regrid["lat"].attrs = dict(
-        long_name="Latitude of T-cell center", units="degree_north"
+        long_name="Latitude of T-cell center",
+        standard_name="latitude",
+        units="degree_north",
     )
     forcing_regrid["lon"].attrs = dict(
         long_name="Longitude of T-cell center",
+        standard_name="longitude",
         units="degrees_east",
     )
     forcing_regrid.attrs = forcing_regrid.attrs | global_attrs

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -1,4 +1,4 @@
-# Copyright 2023 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# Copyright 2025 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
 # SPDX-License-Identifier: Apache-2.0
 
 # =========================================================================================
@@ -7,7 +7,7 @@
 #
 # To run:
 #   python regrid_forcing.py --forcing-filename=<path-to-forcing-file>
-#       --hgrid-filename=<path-to-supergrid-file> --output-file=<path-to-output-file>
+#       --hgrid-filename=<path-to-supergrid-file> --output-filename=<path-to-output-file>
 # these extra arguments are available if required:
 #     --lon-name=<lon-name> --lat-name=<lat-name>
 #
@@ -20,7 +20,7 @@
 # latest version checked in to the main branch of the github repository.
 #
 # Contact:
-#   Dougie Squire <dougal.squire@anu.edu.au>
+#   Dougie Squire <dougie.squire@anu.edu.au>
 #
 # Dependencies:
 #   argparse, xarray, cf_xarray, xesmf
@@ -90,7 +90,7 @@ def main():
     )
 
     parser.add_argument(
-        "--output-file",
+        "--output-filename",
         required=True,
         help="The path to the file to be outputted.",
     )
@@ -112,7 +112,7 @@ def main():
     args = parser.parse_args()
     forcing_filename = os.path.abspath(args.forcing_filename)
     hgrid_filename = os.path.abspath(args.hgrid_filename)
-    output_file = os.path.abspath(args.output_file)
+    output_filename = os.path.abspath(args.output_filename)
     lon_name = args.lon_name
     lat_name = args.lat_name
 
@@ -121,7 +121,7 @@ def main():
     # Add some info about how the file was generated
     runcmd = (
         f"python3 {os.path.basename(this_file)} --forcing-filename={forcing_filename} "
-        f"--hgrid-filename={hgrid_filename} --output-file={output_file}"
+        f"--hgrid-filename={hgrid_filename} --output-filename={output_filename}"
     )
     if lon_name:
         runcmd += f" --lon-name={lon_name}"
@@ -153,6 +153,7 @@ def main():
     # Get source and destination grid
     grid_src = forcing_src[["lon", "lat"]]
 
+    # Destination grid is tracer cell centres
     lon_dest = hgrid["x"][1:-1:2, 1:-1:2].to_dataset(name="lon")
     lat_dest = hgrid["y"][1:-1:2, 1:-1:2].to_dataset(name="lat")
     grid_dest = xr.merge((lon_dest, lat_dest))
@@ -184,7 +185,7 @@ def main():
     forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
 
     # Save output
-    forcing_regrid.to_netcdf(output_file, unlimited_dims="time")
+    forcing_regrid.to_netcdf(output_filename, unlimited_dims="time")
 
 
 if __name__ == "__main__":

--- a/wombat_ic_generation/regrid_forcing.py
+++ b/wombat_ic_generation/regrid_forcing.py
@@ -1,0 +1,193 @@
+# Copyright 2023 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# =========================================================================================
+# Interpolate a provided forcing file to a grid specified by a provided MOM supergrid file for
+# use in the MOM data_table.
+#
+# To run:
+#   python regrid_forcing.py --forcing-filename=<path-to-forcing-file>
+#       --hgrid-filename=<path-to-supergrid-file> --output-file=<path-to-output-file>
+# these extra arguments are available if required:
+#     --lon-name=<lon-name> --lat-name=<lat-name>
+#
+# For more information, run `python regrid_forcing.py -h`
+#
+# The run command and full github url of the current version of this script is added to the
+# metadata of the generated file. This is to uniquely identify the script and inputs used to
+# generate the file. To produce files for sharing, ensure you are using a version of this script
+# which is committed and pushed to github. For files intended for released configurations, use the
+# latest version checked in to the main branch of the github repository.
+#
+# Contact:
+#   Dougie Squire <dougal.squire@anu.edu.au>
+#
+# Dependencies:
+#   argparse, xarray, cf_xarray, xesmf
+# =========================================================================================
+
+import os
+import sys
+from pathlib import Path
+
+import xarray as xr
+import xesmf as xe
+
+path_root = Path(__file__).parents[1]
+sys.path.append(str(path_root))
+
+from scripts_common import get_provenance_metadata, md5sum
+
+
+def _guess_longitude_name(ds):
+    coords = ds.cf.coordinates
+    if "longitude" in coords:
+        if len(coords["longitude"]) == 1:
+            return coords["longitude"][0]
+        else:
+            raise KeyError("Multiple longitude variables exist. Please pass --lon-name")
+    elif "lon" in ds:
+        return "lon"
+    else:
+        raise KeyError(
+            "Cannot automatically determine the name of the longitude variable. Please pass --lon-name"
+        )
+
+
+def _guess_latitude_name(ds):
+    coords = ds.cf.coordinates
+    if "latitude" in coords:
+        if len(coords["latitude"]) == 1:
+            return coords["latitude"][0]
+        else:
+            raise KeyError("Multiple latitude variables exist. Please pass --lat-name")
+    elif "lat" in ds:
+        return "lat"
+    else:
+        raise KeyError(
+            "Cannot automatically determine the name of the latitude variable. Please pass --lat-name"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Interpolate a provided forcing file to a grid specified by a provided MOM supergrid"
+            "file for use in the MOM data_table."
+        )
+    )
+
+    parser.add_argument(
+        "--forcing-filename",
+        required=True,
+        help="The path to the forcing file to interpolate.",
+    )
+
+    parser.add_argument(
+        "--hgrid-filename",
+        required=True,
+        help="The path to the MOM supergrid file to use as a grid for interpolation.",
+    )
+
+    parser.add_argument(
+        "--output-file",
+        required=True,
+        help="The path to the file to be outputted.",
+    )
+
+    parser.add_argument(
+        "--lon-name",
+        type=str,
+        default=None,
+        help="The name of the longitude variable in the input grid. If not passed, an attempt will be made to guess the name.",
+    )
+
+    parser.add_argument(
+        "--lat-name",
+        type=str,
+        default=None,
+        help="The name of the latitude variable in the input grid. If not passed, an attempt will be made to guess the name.",
+    )
+
+    args = parser.parse_args()
+    forcing_filename = os.path.abspath(args.forcing_filename)
+    hgrid_filename = os.path.abspath(args.hgrid_filename)
+    output_file = os.path.abspath(args.output_file)
+    lon_name = args.lon_name
+    lat_name = args.lat_name
+
+    this_file = os.path.normpath(__file__)
+
+    # Add some info about how the file was generated
+    runcmd = (
+        f"python3 {os.path.basename(this_file)} --forcing-filename={forcing_filename} "
+        f"--hgrid-filename={hgrid_filename} --output-file={output_file}"
+    )
+    if lon_name:
+        runcmd += f" --lon-name={lon_name}"
+    if lat_name:
+        runcmd += f" --lat-name={lat_name}"
+
+    file_hashes = [
+        f"{forcing_filename} (md5 hash: {md5sum(forcing_filename)})",
+        f"{hgrid_filename} (md5 hash: {md5sum(hgrid_filename)})",
+    ]
+    global_attrs = {
+        "history": get_provenance_metadata(this_file, runcmd),
+        "inputFile": ", ".join(file_hashes),
+    }
+
+    # Load the input data
+    forcing_src = xr.open_dataset(forcing_filename).compute()
+    hgrid = xr.open_dataset(hgrid_filename).compute()
+
+    # Standardise lon/lat coordinate names
+    if not lon_name:
+        lon_name = _guess_longitude_name(forcing_src)
+
+    if not lat_name:
+        lat_name = _guess_latitude_name(forcing_src)
+
+    forcing_src = forcing_src.rename({lon_name: "lon", lat_name: "lat"})
+
+    # Get source and destination grid
+    grid_src = forcing_src[["lon", "lat"]]
+
+    lon_dest = hgrid["x"][1:-1:2, 1:-1:2].to_dataset(name="lon")
+    lat_dest = hgrid["y"][1:-1:2, 1:-1:2].to_dataset(name="lat")
+    grid_dest = xr.merge((lon_dest, lat_dest))
+
+    # Regrid using bilinear interpolation
+    regridder = xe.Regridder(grid_src, grid_dest, method="bilinear", periodic=True)
+    forcing_regrid = regridder(forcing_src)
+
+    # Add coodinates and metadata required by data_table
+    forcing_regrid = forcing_regrid.assign_coords(
+        lon=lon_dest["lon"], lat=lat_dest["lat"]
+    )
+    forcing_regrid = forcing_regrid.assign_coords(
+        {
+            "nyp": ("nyp", range(forcing_regrid.sizes["nyp"])),
+            "nxp": ("nxp", range(forcing_regrid.sizes["nxp"])),
+        }
+    )
+    forcing_regrid["time"].attrs = dict(axis="T", modulo="y")
+    forcing_regrid["nyp"].attrs = dict(axis="Y")
+    forcing_regrid["nxp"].attrs = dict(axis="X")
+    forcing_regrid["lat"].attrs = dict(
+        long_name="Latitude of T-cell center", units="degree_north"
+    )
+    forcing_regrid["lon"].attrs = dict(
+        long_name="Longitude of T-cell center",
+        units="degrees_east",
+    )
+    forcing_regrid.attrs = forcing_regrid.attrs | global_attrs
+
+    # Save output
+    forcing_regrid.to_netcdf(output_file, unlimited_dims="time")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    main()


### PR DESCRIPTION
This PR adds a script to horizontally regrid the WOMBAT `dust.nc` forcing onto a grid defined by a provided MOM supergrid file and add metadata necessary for use in the MOM `data_table`. While the only application at the moment is the `dust.nc` forcing, the script is written in a relatively general way and should work for other forcing files if/when needed.

I've put the script in the existing `wombat_ic_generation` directory even though strictly it is not related to initial conditions. It felt cleanest at the time to group the WOMBAT scripts together. I'm happy to instead put it in its own dir or rename the `wombat_ic_generation` dir to something like `wombat_input_generation`.