### PR TITLE
Rechunk and persisting daily ice data

### DIFF
--- a/payu_config/postscript/concat_ice_daily.py
+++ b/payu_config/postscript/concat_ice_daily.py
@@ -127,7 +127,7 @@ class Concat_Ice_Daily:
             raise Exception(f"No daily output files found in {directory}")
 
         self.client = start_client(assume_gadi)
-        daily_ds = lazy_open(self.daily_f)
+        daily_ds = lazy_open(self.daily_f).chunk({"time": 31}).persist()
 
         # del incorrect metadata
         del daily_ds.attrs["comment2"]

--- a/test/test_payu_conf/test_concat_ice_daily.py
+++ b/test/test_payu_conf/test_concat_ice_daily.py
@@ -6,7 +6,7 @@ import pandas as pd
 from os import makedirs, chdir
 from pathlib import Path
 
-from payu_config.postscript.concat_ice_daily import concat_ice_daily
+from payu_config.postscript.concat_ice_daily import concat_ice_daily, Concat_Ice_Daily
 
 
 def assert_file_exists(p):

--- a/test/test_payu_conf/test_concat_ice_daily.py
+++ b/test/test_payu_conf/test_concat_ice_daily.py
@@ -215,3 +215,28 @@ def test_leap_year(year, ndays, nmonths, use_dir, hist_base, tmp_path):
 
     for p in daily_paths:
         assert_f_not_exists(p)
+
+
+@pytest.mark.parametrize("ndays", [62, 60, 90, 30, 31, 59])
+def test_chunk_and_persist(hist_base, tmp_path, ndays):
+    """
+    Ensure daily_ds is correctly chunked and persisted with time chunk size = 31.
+    """
+
+    daily_paths = dummy_files("Default", hist_base, ndays, tmp_path)
+    chdir(tmp_path)
+
+    concat = Concat_Ice_Daily(directory=None, assume_gadi=False)
+    daily_ds = concat.daily_ds
+
+    assert isinstance(daily_ds["aice"].data, np.ndarray) is False
+    assert "time" in daily_ds.chunks
+
+    full_chunks = ndays // 31
+    last_chunk = ndays % 31
+    expected_chunks = (31,) * full_chunks + ((last_chunk,) if last_chunk else ())
+
+    assert daily_ds.chunks["time"] == expected_chunks
+
+    # Cleanup
+    concat.client.close()


### PR DESCRIPTION
closes https://github.com/ACCESS-NRI/om3-scripts/issues/73

This improves the performance of the `concat_ice_daily.py` by rechunking the daily dataset along the time dimension into 31 day blocks, and persisting the rechunked dataset to memory before further processing.

For example, processing 3 years of daily cice output now takes ~7 minutes, down from 20 minutes.
