### PR TITLE
wombat_ic_generation: compatibility with older versions of FMS

### DIFF
--- a/wombat_ic_generation/SFe_climatology.py
+++ b/wombat_ic_generation/SFe_climatology.py
@@ -85,7 +85,8 @@ def main():
     g_per_kg = 1000
     g_per_mol = 55.845
     SFe = g_per_kg / g_per_mol * ds[["SFe"]]
-    SFe.SFe.attrs["unit"] = "mol/m2/s"
+    SFe.SFe.attrs["units"] = "mol/m2/s"
+    del SFe.SFe.attrs["unit"]
 
     # Create time array at middle of month
     # FMS requires calendar to be one of: noleap, 365_day, 365_days, 360_day,
@@ -107,13 +108,21 @@ def main():
     )
 
     # Update attributes
-    SFe_clim.attrs["Title"] = (
+    SFe_clim.attrs["title"] = (
         "Monthly climatological (1980-2014) soluble iron and dust deposition"
     )
+    del SFe_clim.attrs["Title"]
     SFe_clim.attrs |= {
         "DOI": "https://doi.org/10.7298/xqqj-qk90 (file: CESM-MIMI_1980-2015_CAM4-6MEAN_MonthlyDep_Hamiltonetal2020.nc)",
     }
     SFe_clim.attrs |= history_attrs
+    SFe_clim.lon.attrs["standard_name"] = "longitude"
+    del SFe_clim.lon.attrs["name"]
+    SFe_clim.lat.attrs["standard_name"] = "latitude"
+    del SFe_clim.lat.attrs["name"]
+    SFe_clim.time.attrs["standard_name"] = "time"
+    SFe_clim.SFe.attrs["long_name"] = SFe_clim.SFe.attrs["name"]
+    del SFe_clim.SFe.attrs["name"]
 
     # Add climatology_bounds
     SFe_clim.time.attrs["climatology"] = "climatology_bounds"
@@ -132,7 +141,7 @@ def main():
         use_cftime=True,
     )[1:]
     climatology_bounds = xr.DataArray(
-        np.vstack((start_times, end_times)), dims=["nv", "time"]
+        np.vstack((start_times, end_times)).T, dims=["time", "nv"]
     )
     SFe_clim = SFe_clim.assign_coords({"climatology_bounds": climatology_bounds})
 

--- a/wombat_ic_generation/SFe_climatology.py
+++ b/wombat_ic_generation/SFe_climatology.py
@@ -138,20 +138,17 @@ def main():
 
     comp = dict(zlib=True, complevel=4)
     encoding = {var: comp for var in SFe_clim.data_vars}
-    encoding |= {
-        "time": {
-            "units": "days since 0001-01-01 00:00:00.000000",
-            "calendar": calendar,
-        },
-        "climatology_bounds": {
-            "units": "days since 0001-01-01 00:00:00.000000",
-            "calendar": calendar,
-        },
+    # Time coords should be double type according for CF conventions
+    time_encoding = {
+        "dtype": "float64",
+        "units": "days since 0001-01-01 00:00:00.000000",
+        "calendar": calendar,
     }
-    unlimited_dims = "time" if "time" in SFe_clim.dims else None
-    SFe_clim.to_netcdf(
-        output_filename, unlimited_dims=unlimited_dims, encoding=encoding
-    )
+    encoding |= {
+        "time": time_encoding,
+        "climatology_bounds": time_encoding,
+    }
+    SFe_clim.to_netcdf(output_filename, unlimited_dims="time", encoding=encoding)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR includes some minor changes to types and attributes of files generated by `SFe_climatology.py` and `regrid_forcing.py` to allow them to be used by older versions of FMS (as used in ACCESS-OM2 and ACCESS-ESM1.6).

I also took the opportunity to get the output from `SFe_climatology.py` slightly closer to CF compliance. The output of `cchecker.py` is now at most Highly Recommended changes (previously [this](https://github.com/ACCESS-NRI/om3-scripts/pull/82#issuecomment-3247776604)):

```
--------------------------------------------------------------------------------
                         IOOS Compliance Checker Report
                                 Version 5.3.0
                     Report generated 2025-09-17T00:42:26Z
                                    acdd:1.3
http://wiki.esipfed.org/index.php?title=Category:Attribute_Conventions_Dataset_Discovery
--------------------------------------------------------------------------------
                               Corrective Actions
CESM-MIMI_1980-2015_CAM4-6MEAN_MonthlyDep_Hamiltonetal2020_clim.nc has 5 potential issues


                               Highly Recommended
--------------------------------------------------------------------------------
Global Attributes
* Conventions does not contain 'ACDD-1.3'
* keywords not present
* summary not present

variable "SFe" missing the following attributes:
* coverage_content_type
* standard_name

variable "lat" missing the following attributes:
* long_name

variable "lon" missing the following attributes:
* long_name

variable "time" missing the following attributes:
* long_name
```

I've tested using files generated with these scripts in ACCESS-OM3 (new FMS) and ACCESS-ESM1.6 (old FMS).